### PR TITLE
Drop return-by-reference for __get()

### DIFF
--- a/src/Scream.php
+++ b/src/Scream.php
@@ -57,7 +57,7 @@ trait Scream
 	 * @param string $name property name
 	 * @throws \Kdyby\StrictObjects\MemberAccessException
 	 */
-	public function &__get($name)
+	public function __get($name)
 	{
 		$class = get_class($this);
 		$hint = Suggester::suggestProperty($class, $name);


### PR DESCRIPTION
It's pointless as it doesn't return anything anyway.

It's not a BC break as adding a reference in a subclass would be valid: https://3v4l.org/Utl0h