### PR TITLE
Make the undeclared property getter compatible with Nette DI

### DIFF
--- a/src/PropertyReadScreamer.php
+++ b/src/PropertyReadScreamer.php
@@ -13,7 +13,7 @@ trait PropertyReadScreamer
      *
      * @throws UndefinedProperty
      */
-    public function __get(string $name)
+    public function &__get(string $name)
     {
         throw UndefinedProperty::read($this, $name);
     }


### PR DESCRIPTION
Make the undeclared property getter compatible with Nette\DI\CompilerExtension::__get($name)

Signed-off-by: Roman Ondráček <ondracek.roman@centrum.cz>