### PR TITLE
Add php 7.2, php 7.3 and php 7.4 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
 
 php:
   - 7.2
+  - 7.3
+  - 7.4
   - nightly
 
 before_install:


### PR DESCRIPTION
# Changed log
- Add `php-7.3` and `php-7.4` version tests during Travis CI build.